### PR TITLE
Add detailed output metadata field to cut-finder output

### DIFF
--- a/circuit_knitting/cutting/automated_cut_finding.py
+++ b/circuit_knitting/cutting/automated_cut_finding.py
@@ -133,6 +133,9 @@ def find_cuts(
             metadata["cuts"].append(("Wire Cut", i))
     metadata["sampling_overhead"] = opt_out.upper_bound_gamma() ** 2
     metadata["minimum_reached"] = optimizer.minimum_reached()
+    metadata["actions"] = [
+        (x[0], x[1]) for x in opt_out.cut_actions_sublist()
+    ]  # pragma: no cover
 
     return circ_out, metadata
 

--- a/circuit_knitting/cutting/automated_cut_finding.py
+++ b/circuit_knitting/cutting/automated_cut_finding.py
@@ -133,9 +133,10 @@ def find_cuts(
             metadata["cuts"].append(("Wire Cut", i))
     metadata["sampling_overhead"] = opt_out.upper_bound_gamma() ** 2
     metadata["minimum_reached"] = optimizer.minimum_reached()
-    metadata["actions"] = [
-        (x[0], x[1]) for x in opt_out.cut_actions_sublist()
-    ]  # pragma: no cover
+    if opt_out.cut_actions_sublist is not None:
+        metadata["actions"] = [(x[0], x[1]) for x in opt_out.cut_actions_sublist()]
+    else:
+        metadata["actions"] = "No cuts found"
 
     return circ_out, metadata
 

--- a/docs/circuit_cutting/tutorials/04_automatic_cut_finding.ipynb
+++ b/docs/circuit_cutting/tutorials/04_automatic_cut_finding.ipynb
@@ -52,13 +52,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "The actions and locations associated with the located cuts are [('CutRightWire', WireCutLocation(instruction_id=19, gate_name='cry', qubits=[6, 5], input=2)), ('CutTwoQubitGate', CutLocation(instruction_id=27, gate_name='crz', qubits=[6, 3]))]\n",
       "Found solution using 2 cuts with a sampling overhead of 127.06026169907257.\n",
       "Lowest cost solution found: True.\n",
       "Wire Cut at circuit instruction index 19\n",
@@ -72,7 +73,7 @@
        "<Figure size 1367.11x494.978 with 1 Axes>"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -91,6 +92,11 @@
     "device_constraints = DeviceConstraints(qubits_per_subcircuit=4)\n",
     "\n",
     "cut_circuit, metadata = find_cuts(circuit, optimization_settings, device_constraints)\n",
+    "\n",
+    "# Uncomment the line below to see details of the cut-scheme where\n",
+    "# a list of tuples specifying the action and its location is given.\n",
+    "# print(f'The actions and locations associated with the located cuts are {metadata[\"actions\"]}')\n",
+    "\n",
     "print(\n",
     "    f'Found solution using {len(metadata[\"cuts\"])} cuts with a sampling '\n",
     "    f'overhead of {metadata[\"sampling_overhead\"]}.\\n'\n",


### PR DESCRIPTION
@caleb-johnson , when looking over the tutorial on [automatic cut finding](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/blob/main/docs/circuit_cutting/tutorials/04_automatic_cut_finding.ipynb), I realized that under some circumstances, the user may wish to see more details of which cuts were actually found and where (in particular, what were the names and qubits associated with the gates that were involved). I added a metadata field to this effect and I wonder if an a priori commented line that lets the user see more of these details of the cut scheme is worth adding to the tutorial.

- [ ] Needs test.
- [ ] The qubit id's seem to be outputted incorrectly. This needs to be fixed.