### PR TITLE
Deprecate CKT in favor of qiskit-addon-cutting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,11 @@
-<!-- SHIELDS -->
-<div align="left">
-
-  [![Stability](https://img.shields.io/badge/Stability-alpha-f4d03f.svg)](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/releases)
-  [![Release](https://img.shields.io/pypi/v/circuit-knitting-toolbox.svg?label=Release)](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/releases)
-  ![Platform](https://img.shields.io/badge/%F0%9F%92%BB%20Platform-Linux%20%7C%20macOS%20%7C%20Windows-informational)
-  [![Python](https://img.shields.io/pypi/pyversions/circuit-knitting-toolbox?label=Python&logo=python)](https://www.python.org/)
-  [![Qiskit](https://img.shields.io/badge/Qiskit%20-%20%3E%3D1.0%20-%20%236133BD?logo=Qiskit)](https://github.com/Qiskit/qiskit)
-<br />
-  [![Docs (stable)](https://img.shields.io/badge/%F0%9F%93%84%20Docs-stable-blue.svg)](https://qiskit-extensions.github.io/circuit-knitting-toolbox/)
-  [![DOI](https://zenodo.org/badge/543181258.svg)](https://zenodo.org/badge/latestdoi/543181258)
-  [![License](https://img.shields.io/github/license/Qiskit-Extensions/circuit-knitting-toolbox?label=License)](LICENSE.txt)
-  [![Downloads](https://img.shields.io/pypi/dm/circuit-knitting-toolbox.svg?label=Downloads)](https://pypi.org/project/circuit-knitting-toolbox/)
-  [![Tests](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/actions/workflows/test_latest_versions.yml/badge.svg)](https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/actions/workflows/test_latest_versions.yml)
-  [![Coverage](https://coveralls.io/repos/github/Qiskit-Extensions/circuit-knitting-toolbox/badge.svg?branch=main)](https://coveralls.io/github/Qiskit-Extensions/circuit-knitting-toolbox?branch=main)
-
 # Circuit Knitting Toolbox
 
-### Table of Contents
+This package has been renamed to `qiskit-addon-cutting`.
 
-* [About](#about)
-* [Documentation](#documentation)
-* [Installation](#installation)
-* [Deprecation Policy](#deprecation-policy)
-* [References](#references)
-* [License](#license)
+- Documentation: https://qiskit.github.io/qiskit-addon-cutting/
+- GitHub: https://github.com/Qiskit/qiskit-addon-cutting
+- PyPI: https://pypi.org/project/qiskit-addon-cutting/
 
-----------------------------------------------------------------------------------------------------
-
-### About
-
-Circuit Knitting is the process of decomposing a larger quantum circuit into many smaller circuits, executing those circuits on a quantum processor(s), and then knitting their results into a reconstruction of the original circuit's outcome.
-
-The toolbox currently contains the following tools:
-- Circuit Cutting [[1-5]](#references)
- 
-For a more detailed discussion on circuit cutting, check out our [technical guide](https://qiskit-extensions.github.io/circuit-knitting-toolbox/circuit_cutting/explanation/index.html#overview-of-circuit-cutting).
-
-----------------------------------------------------------------------------------------------------
-  
-### Documentation
-
-All CKT documentation is available at https://qiskit-extensions.github.io/circuit-knitting-toolbox/.
-
-----------------------------------------------------------------------------------------------------
-  
-### Installation
-
-We encourage installing CKT via ``pip``, when possible.
-
-```bash
-pip install 'circuit-knitting-toolbox'
-```
-
-For information on installing from source, running CKT in a container, and platform support, refer to the [installation instructions](https://qiskit-extensions.github.io/circuit-knitting-toolbox/install.html) in the CKT documentation.
-
-----------------------------------------------------------------------------------------------------
-
-### Deprecation Policy
-
-This project is meant to evolve rapidly and, as such, does not follow [Qiskit's deprecation policy](https://github.com/Qiskit/qiskit/blob/main/DEPRECATION.md).  We may occasionally make breaking changes in order to improve the user experience.  When possible, we will keep old interfaces and mark them as deprecated, as long as they can co-exist with the new ones.  Each substantial improvement, breaking change, or deprecation will be documented in the [release notes](https://qiskit-extensions.github.io/circuit-knitting-toolbox/release-notes.html).
-
-----------------------------------------------------------------------------------------------------
-
-### References
-
-[1] Kosuke Mitarai, Keisuke Fujii, [Constructing a virtual two-qubit gate by sampling single-qubit operations](https://iopscience.iop.org/article/10.1088/1367-2630/abd7bc), New J. Phys. 23 023021.
-
-[2] Kosuke Mitarai, Keisuke Fujii, [Overhead for simulating a non-local channel with local channels by quasiprobability sampling](https://quantum-journal.org/papers/q-2021-01-28-388/), Quantum 5, 388 (2021).
-
-[3] Christophe Piveteau, David Sutter, [Circuit knitting with classical communication](https://arxiv.org/abs/2205.00016), arXiv:2205.00016 [quant-ph].
-
-[4] Lukas Brenner, Christophe Piveteau, David Sutter, [Optimal wire cutting with classical communication](https://arxiv.org/abs/2302.03366), arXiv:2302.03366 [quant-ph].
-
-[5] K. Temme, S. Bravyi, and J. M. Gambetta, [Error mitigation for short-depth quantum circuits](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.119.180509), Physical Review Letters, 119(18), (2017).
-  
-----------------------------------------------------------------------------------------------------
-
-<!-- LICENSE -->
 ### License
-[Apache License 2.0](LICENSE.txt)
+
+-[Apache License 2.0](LICENSE.txt)

--- a/circuit_knitting/__init__.py
+++ b/circuit_knitting/__init__.py
@@ -10,3 +10,14 @@
 # that they have been altered from the originals.
 
 """Main Circuit Knitting Toolbox public functionality."""
+
+from warnings import warn
+
+warn(
+    "The circuit-knitting-toolbox package has been deprecated upon its final "
+    "release, v0.8.0.  It has been renamed to qiskit-addon-cutting.  "
+    "Users are encouraged to migrate to the new package name and import "
+    "locations in order to receive further updates.",
+    category=DeprecationWarning,
+    stacklevel=1,
+)

--- a/circuit_knitting/cutting/__init__.py
+++ b/circuit_knitting/cutting/__init__.py
@@ -78,6 +78,8 @@ Quasi-Probability Decomposition (QPD)
     qpd.qpdbasis_from_instruction
 """
 
+from warnings import warn
+
 from .cutting_decomposition import (
     partition_circuit_qubits,
     partition_problem,
@@ -102,3 +104,12 @@ __all__ = [
     "DeviceConstraints",
     "OptimizationParameters",
 ]
+
+warn(
+    "The `circuit_knitting.cutting` import location has been deprecated and "
+    "has been moved to `qiskit_addon_cutting` in the "
+    "qiskit-addon-cutting package.  Users are encouraged to migrate to the "
+    "new package name and import locations to receive further updates.",
+    category=DeprecationWarning,
+    stacklevel=1,
+)

--- a/circuit_knitting/utils/__init__.py
+++ b/circuit_knitting/utils/__init__.py
@@ -48,3 +48,14 @@ Transpiler passes (:mod:`circuit_knitting.utils.transpiler_passes`)
 
 .. automodule:: circuit_knitting.utils.transpiler_passes
 """
+
+from warnings import warn
+
+warn(
+    "The `circuit_knitting.utils` import location has been deprecated and "
+    "has been moved to `qiskit_addon_cutting.utils` in the "
+    "qiskit-addon-cutting package.  Users are encouraged to migrate to the "
+    "new package name and import locations to receive further updates.",
+    category=DeprecationWarning,
+    stacklevel=1,
+)

--- a/releasenotes/notes/renamed-and-deprecated-ee0f28ea333051a5.yaml
+++ b/releasenotes/notes/renamed-and-deprecated-ee0f28ea333051a5.yaml
@@ -1,0 +1,10 @@
+---
+deprecations:
+  - |
+    The ``circuit-knitting-toolbox`` package has been deprecated, and
+    no further releases are expected to be made.  Users are encouraged
+    to migrate to the ``qiskit-addon-cutting`` package and to update
+    their import locations as follows:
+
+    - ``circuit_knitting.cutting`` -> ``qiskit_addon_cutting``
+    - ``circuit_knitting.utils`` -> ``qiskit_addon_cutting.utils``


### PR DESCRIPTION
- [x] Add release note?  Or will the release prelude be enough?
- [x] Add a note at the top of the README so that it will be obvious from looking at the package's pypi page that it has been deprecated in factor of qiskit-addon-cutting.