### PR TITLE
fix: broken link in Release shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- SHIELDS -->
 <div align="left">
 
-  [![Release](https://img.shields.io/pypi/v/qiskit-addon-cutting.svg?label=Release)](https://github.com/Qiskit-Extensions/qiskit-addon-cutting/releases)
+  [![Release](https://img.shields.io/pypi/v/qiskit-addon-cutting.svg?label=Release)](https://github.com/Qiskit/qiskit-addon-cutting/releases)
   ![Platform](https://img.shields.io/badge/%F0%9F%92%BB%20Platform-Linux%20%7C%20macOS%20%7C%20Windows-informational)
   [![Python](https://img.shields.io/pypi/pyversions/qiskit-addon-cutting?label=Python&logo=python)](https://www.python.org/)
   [![Qiskit](https://img.shields.io/badge/Qiskit%20-%20%3E%3D1.1%20-%20%236133BD?logo=Qiskit)](https://github.com/Qiskit/qiskit)


### PR DESCRIPTION
There are also more mentions of `Qiskit-Extensions/circuit-knitting-toolbox` in some old release notes but I did not address those yet.

Those links appear to be direct github links to jupyter notebooks rather than links pointing to their HTML rendered versions. Might be a bit more involved to address.