### PR TITLE
Fix two more API links to non-API docs

### DIFF
--- a/releasenotes/notes/0.2/gate-cutting-workflow-ebbedbdb1313b258.yaml
+++ b/releasenotes/notes/0.2/gate-cutting-workflow-ebbedbdb1313b258.yaml
@@ -14,7 +14,7 @@ prelude: |
     *execution* of many subexperiments, and *reconstruction* of a simulated output of the original problem.
     These steps may be implemented with the :mod:`~circuit_knitting_toolbox.circuit_cutting` package using only a few primary
     functions, namely, the :func:`.partition_problem`, :func:`.decompose_gates`, :func:`.execute_experiments`, and :func:`.reconstruct_expectation_values` functions.
-    Check out the :ref:`tutorials <circuit cutting tutorials>` for a look at a couple of example circuit cutting workflows.
+    Check out the `tutorials <https://qiskit.github.io/qiskit-addon-cutting/tutorials/index.html>`__ for a look at a couple of example circuit cutting workflows.
 
 features:
   - |

--- a/releasenotes/notes/0.3/two-qubit-wire-cutting-27aff379403ea226.yaml
+++ b/releasenotes/notes/0.3/two-qubit-wire-cutting-27aff379403ea226.yaml
@@ -2,5 +2,4 @@
 features:
   - |
     The :mod:`circuit_knitting.cutting` module now supports wire
-    cutting.  There is a :ref:`new tutorial <circuit cutting
-    tutorials>` that explains how to use it.
+    cutting.  There is a `new tutorial <https://qiskit.github.io/qiskit-addon-cutting/tutorials/index.html>`__ that explains how to use it.


### PR DESCRIPTION
These were missed in https://github.com/Qiskit/qiskit-addon-cutting/pull/693.