### PR TITLE
Fix broken external docs links

### DIFF
--- a/qiskit_addon_cutting/utils/simulation.py
+++ b/qiskit_addon_cutting/utils/simulation.py
@@ -142,7 +142,7 @@ class ExactSampler(BaseSamplerV1):
     :mod:`qiskit_aer.primitives` do not currently support all of the above
     functionality.  Related upstream issues:
 
-    - https://github.com/Qiskit/qiskit-terra/issues/9657
+    - https://github.com/Qiskit/qiskit/issues/9657
     - https://github.com/Qiskit/qiskit-aer/issues/1810
     - https://github.com/Qiskit/qiskit-aer/issues/1811
     """

--- a/releasenotes/notes/0.2/gate-cutting-workflow-ebbedbdb1313b258.yaml
+++ b/releasenotes/notes/0.2/gate-cutting-workflow-ebbedbdb1313b258.yaml
@@ -32,7 +32,7 @@ issues:
     The :mod:`~circuit_knitting_toolbox.circuit_cutting` package only supports :class:`~qiskit.quantum_info.PauliList` observables for calculating expectation values. Support for calculating
     expectation values for more observable types, including :class:`~qiskit.quantum_info.SparsePauliOp`, is expected no sooner than 0.3.0.
   - |
-    The ``Sampler``\ s from Qiskit and Qiskit Aer do not support mid-circuit measurements in statevector mode. For more on generating exact quasi-distributions using the :class:`~qiskit.primitives.BaseSampler` interface, check out our `how-to guide <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/tree/main/docs/circuit_cutting/how-tos/how_to_generate_exact_quasi_dists_from_sampler.ipynb>`_.
+    The ``Sampler``\ s from Qiskit and Qiskit Aer do not support mid-circuit measurements in statevector mode. For more on generating exact quasi-distributions using the :class:`~qiskit.primitives.BaseSampler` interface, check out our `how-to guide <https://github.com/Qiskit/qiskit-addon-cutting/blob/stable/0.7/docs/circuit_cutting/how-tos/how_to_generate_exact_quasi_dists_from_sampler.ipynb>`_.
   - |
     The :mod:`~circuit_knitting_toolbox.circuit_cutting` package generally does not yet support input circuits with user-added
     classical bits, so by extension, it does not yet support dynamic circuits.

--- a/releasenotes/notes/0.7/deprecate-cutqc-7541c514bd96fb05.yaml
+++ b/releasenotes/notes/0.7/deprecate-cutqc-7541c514bd96fb05.yaml
@@ -4,4 +4,4 @@ deprecations:
     The ``circuit_knitting.cutting.cutqc`` package is deprecated and will be removed no sooner than Circuit Knitting Toolbox 0.8.0. 
     The wire cutting functionality in the :mod:`circuit_knitting.cutting` package is what will be maintained going forward. 
     Additionally, there is a new automated gate and wire cut-finding functionality in the :mod:`circuit_knitting.cutting.automated_cut_finding` module.
-    A `tutorial <https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/blob/main/docs/circuit_cutting/tutorials/04_automatic_cut_finding.ipynb>`__ has been added to demonstrate automated cut-finding.
+    A `tutorial <https://github.com/Qiskit/qiskit-addon-cutting/blob/stable/0.7/docs/circuit_cutting/tutorials/04_automatic_cut_finding.ipynb>`__ has been added to demonstrate automated cut-finding.


### PR DESCRIPTION
These were caught by the qiskit/documentation external link checker.