### PR TITLE
Update some Qiskit Terra links to Qiskit repo

### DIFF
--- a/qiskit_addon_cutting/qpd/decompositions.py
+++ b/qiskit_addon_cutting/qpd/decompositions.py
@@ -83,7 +83,7 @@ def qpdbasis_from_instruction(gate: Instruction, /) -> QPDBasis:
     All two-qubit gates which implement the :meth:`~qiskit.circuit.Gate.to_matrix` method are
     supported.  This should include the vast majority of gates with no unbound
     parameters, but there are some special cases (see, e.g., `qiskit issue #10396
-    <https://github.com/Qiskit/qiskit-terra/issues/10396>`__).
+    <https://github.com/Qiskit/qiskit/issues/10396>`__).
 
     The :class:`.Move` operation, which can be used to specify a wire cut,
     is also supported.
@@ -323,7 +323,7 @@ def _(unused_gate: iSwapGate):
 def _(unused_gate: DCXGate):
     retval = qpdbasis_from_instruction(iSwapGate())
     # Modify basis according to DCXGate definition in Qiskit circuit library
-    # https://github.com/Qiskit/qiskit-terra/blob/e9f8b7c50968501e019d0cb426676ac606eb5a10/qiskit/circuit/library/standard_gates/equivalence_library.py#L938-L944
+    # https://github.com/Qiskit/qiskit/blob/e9f8b7c50968501e019d0cb426676ac606eb5a10/qiskit/circuit/library/standard_gates/equivalence_library.py#L938-L944
     for operations in unique_by_id(m[0] for m in retval.maps):
         operations.insert(0, SdgGate())
         operations.insert(0, HGate())
@@ -486,7 +486,7 @@ def _(gate: CXGate | CYGate | CZGate | CHGate):
 def _(unused_gate: ECRGate):
     retval = qpdbasis_from_instruction(CXGate())
     # Modify basis according to ECRGate definition in Qiskit circuit library
-    # https://github.com/Qiskit/qiskit-terra/blob/d9763523d45a747fd882a7e79cc44c02b5058916/qiskit/circuit/library/standard_gates/equivalence_library.py#L656-L663
+    # https://github.com/Qiskit/qiskit/blob/d9763523d45a747fd882a7e79cc44c02b5058916/qiskit/circuit/library/standard_gates/equivalence_library.py#L656-L663
     for operations in unique_by_id(m[0] for m in retval.maps):
         operations.insert(0, SGate())
         operations.append(XGate())

--- a/qiskit_addon_cutting/utils/observable_grouping.py
+++ b/qiskit_addon_cutting/utils/observable_grouping.py
@@ -92,7 +92,7 @@ def most_general_observable(
     # it _could_ be, *especially* if given a PauliList.
     #
     # Indeed, this can be made better by using pauli.x and pauli.z arrays
-    # https://github.com/Qiskit/qiskit-terra/blob/061aee2685676271fd0860d0a2d699e36941ae5e/qiskit/primitives/backend_estimator.py#L403-L404
+    # https://github.com/Qiskit/qiskit/blob/061aee2685676271fd0860d0a2d699e36941ae5e/qiskit/primitives/backend_estimator.py#L403-L404
     for j, obs in enumerate(commuting_observables):
         if not isinstance(obs, Pauli):
             raise ValueError("Input sequence includes something other than a Pauli.")
@@ -135,7 +135,7 @@ class CommutingObservableGroup:
 
     def __post_init__(self) -> None:
         """Post-init method for the data class."""
-        # TODO(perf): These loops could be faster; see e.g. https://github.com/Qiskit/qiskit-terra/blob/061aee2685676271fd0860d0a2d699e36941ae5e/qiskit/primitives/backend_estimator.py#L398-L413
+        # TODO(perf): These loops could be faster; see e.g. https://github.com/Qiskit/qiskit/blob/061aee2685676271fd0860d0a2d699e36941ae5e/qiskit/primitives/backend_estimator.py#L398-L413
         pauli_indices: list[int] = [
             i for i, pauli in enumerate(self.general_observable) if pauli != _I
         ]

--- a/test/qpd/test_qpd_basis.py
+++ b/test/qpd/test_qpd_basis.py
@@ -136,7 +136,7 @@ class TestQPDBasis(unittest.TestCase):
         with self.subTest("Implicitly supported gate"):
             # For implicitly supported gates, we can detect that `to_matrix`
             # failed, but there are other possible explanations, too.  See
-            # https://github.com/Qiskit/qiskit-terra/issues/10396
+            # https://github.com/Qiskit/qiskit/issues/10396
             with pytest.raises(ValueError) as e_info:
                 QPDBasis.from_instruction(XXPlusYYGate(Parameter("θ")))
             assert (


### PR DESCRIPTION
The qiskit/documentation external link checker did not like a link to qiskit-terra, which is now qiskit. While it redirects fine, we intentionally try to avoid linking to redirects.