### PR TITLE
Disallow Qiskit 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "scipy>=1.5.2",
     "rustworkx>=0.14.0",
     "qiskit-aer>=0.14.0.1",
-    "qiskit>=1.1.0, <2.0",
+    "qiskit>=1.1.0, !=1.3.0, <2.0",
     "qiskit-ibm-runtime>=0.24.0",
 ]
 

--- a/releasenotes/notes/no-qiskit-1.3.0-8acc5be0edb2f43a.yaml
+++ b/releasenotes/notes/no-qiskit-1.3.0-8acc5be0edb2f43a.yaml
@@ -1,0 +1,8 @@
+---
+other:
+  - |
+    This addon is now marked as being incompatible with Qiskit 1.3.0, as the
+    second cutting tutorial fails to execute due to a bug in Qiskit 1.3.0.
+    See discussion in
+    `issue #714 <https://github.com/Qiskit/qiskit-addon-cutting/issues/714>`__
+    for more information.


### PR DESCRIPTION
See discussion in #714.  This will fix CI, and we might as well disallow installing a version of Qiskit that is known to fail CI. By the time this change makes it to a release, the 1.3.1 release will likely be out, so this will be an insignificant restriction by then.

- [x] release note