### PR TITLE
Add a linter to check the images' alt text

### DIFF
--- a/tools/verify_images.py
+++ b/tools/verify_images.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Utility script to verify that all images have alt text"""
+
+from pathlib import Path
+import multiprocessing
+import sys
+import glob
+
+# Dictionary to allowlist lines of code that the checker will not error
+# Format: {"file_path": [list_of_line_numbers]}
+ALLOWLIST_MISSING_ALT_TEXT = {
+    "qiskit_addon_cutting/instructions/move.py": [50]
+}
+
+
+def is_image(line: str) -> bool:
+    return line.strip().startswith((".. image:", ".. plot:"))
+
+
+def is_option(line: str) -> bool:
+    return line.strip().startswith(":")
+
+def in_allowlist(filename: str, line_num: int) -> bool:
+    return line_num in ALLOWLIST_MISSING_ALT_TEXT.get(filename, [])
+
+
+def validate_image(file_path: str) -> tuple[str, list[str]]:
+    """Validate all the images of a single file"""
+    invalid_images: list[str] = []
+
+    lines = Path(file_path).read_text().splitlines()
+
+    line_index = 0
+    image_found = False
+    image_line = -1
+    options: list[str] = []
+
+    while line_index < len(lines):
+        line = lines[line_index].strip()
+
+        if image_found and not is_option(line) and not is_valid_image(options):
+            invalid_images.append(f"- Error in line {image_line}: {lines[image_line-1].strip()}")
+            image_found = False
+            options = []
+            continue
+
+        if image_found and is_option(line):
+            options.append(line)
+
+        if is_image(line) and not in_allowlist(file_path, line_index + 1):
+            image_found = True
+            image_line = line_index + 1
+            options = []
+
+        line_index += 1
+
+    return (file_path, invalid_images)
+
+
+def is_valid_image(options: list[str]) -> bool:
+    alt_exists = any(option.startswith(":alt:") for option in options)
+    nofigs_exists = any(option.startswith(":nofigs:") for option in options)
+
+    # Only `.. plot::`` directives without the `:nofigs:` option are required to have alt text.
+    # Meanwhile, all `.. image::` directives need alt text and they don't have a `:nofigs:` option.
+    return alt_exists or nofigs_exists
+
+def main() -> None:
+    files = glob.glob("qiskit_addon_cutting/**/*.py", recursive=True)
+    
+    with multiprocessing.Pool() as pool:
+        results = pool.map(validate_image, files)
+
+    failed_files = [x for x in results if len(x[1])]
+
+    if not len(failed_files):
+        print("✅ All images have alt text")
+        sys.exit(0)
+
+    print("💔 Some images are missing the alt text", file=sys.stderr)
+
+    for filename, image_errors in failed_files:
+        print(f"\nErrors found in {filename}:", file=sys.stderr)
+
+        for image_error in image_errors:
+            print(image_error, file=sys.stderr)
+
+    print(
+        "\nAlt text is crucial for making documentation accessible to all users. It should serve the same purpose as the images on the page, conveying the same meaning rather than describing visual characteristics. When an image contains words that are important to understanding the content, the alt text should include those words as well.",
+        file=sys.stderr,
+    )
+
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/verify_images.py
+++ b/tools/verify_images.py
@@ -55,13 +55,18 @@ def validate_image(file_path: str) -> tuple[str, list[str]]:
     options: list[str] = []
 
     for line_index, line in enumerate(lines):
-        if image_found and is_option(line):
-            options.append(line)
-            continue
+        if image_found:
+            if is_option(line):
+                options.append(line)
+                continue
 
-        if image_found and not is_valid_image(options):
-            image_line = line_index - len(options)
-            invalid_images.append(f"- Error in line {image_line}: {lines[image_line-1].strip()}")
+            # Else, the prior image_found has no more options so we should determine if it was valid.
+            #
+            # Note that, either way, we do not early exit out of the loop iteration because this `line`
+            # might be the start of a new image.
+            if not is_valid_image(options):
+                image_line = line_index - len(options)
+                invalid_images.append(f"- Error in line {image_line}: {lines[image_line-1].strip()}")
 
         image_found = is_image(line)
         options = []
@@ -75,7 +80,7 @@ def main() -> None:
     with multiprocessing.Pool() as pool:
         results = pool.map(validate_image, files)
 
-    failed_files = [x for x in results if len(x[1])]
+    failed_files = {file: image_errors for file, image_errors in results if image_errors}
 
     if not len(failed_files):
         print("✅ All images have alt text")
@@ -83,8 +88,8 @@ def main() -> None:
 
     print("💔 Some images are missing the alt text", file=sys.stderr)
 
-    for filename, image_errors in failed_files:
-        print(f"\nErrors found in {filename}:", file=sys.stderr)
+    for file, image_errors in failed_files.items():
+        print(f"\nErrors found in {file}:", file=sys.stderr)
 
         for image_error in image_errors:
             print(image_error, file=sys.stderr)

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ commands =
   mypy qiskit_addon_cutting/
   reno lint
   pylint -rn qiskit_addon_cutting/ test/
+  python tools/verify_images.py
   nbqa pylint -rn docs/
 
 [testenv:{,py-,py3-,py38-,py39-,py310-,py311-,py312-,py313-}notebook]


### PR DESCRIPTION
In order to meet the [IBM Accessibility Requirements](https://www.ibm.com/able/requirements/requirements) for the API docs, we need to ensure that all images have appropriate alt text so that users can understand any meaningful visuals. The alt text should serve the same purpose as the images on the page, conveying the same meaning rather than describing visual characteristics. In addition, if an image contains important words for understanding the content, the alt text should include those words as well.

This PR adds a linter to check that all images have alt text. The current invalid images, if any, have been included in an allowlist that will help us to not break CI before the text is added.

If the script detects an image without alt text, it will show an error indicating the file where the image is located and the line where we are using a sphinx directive like `.. image::` or `.. plot::` that generates an image. Example:

```
💔 Some images are missing the alt text

Errors found in qiskit_ibm_runtime/fake_provider/__init__.py:
- Error in line 34: .. plot::

Alt text is crucial for making documentation accessible to all users. It should serve the same purpose as the images on the page, conveying the same meaning rather than describing visual characteristics. When an image contains words that are important to understanding the content, the alt text should include those words as well.
```

To fix the error, the `:alt: [Your text here]` option must be added under the lines indicated in the error messages. However, If the `.. plot::` directive is used, but no image is generated, you can use the option `:nofigs:`.