### PR TITLE
Work around #714 by disabling the second tutorial on dev version CI

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -45,4 +45,4 @@ jobs:
         run: |
           toxpyversion=$(echo ${{ matrix.python-version }} | sed -E 's/^([0-9]+)\.([0-9]+).*$/\1\2/')
           tox -epy${toxpyversion} -- --run-slow
-          tox -epy${toxpyversion}-notebook
+          tox -epy${toxpyversion}-notebook -- --ignore=docs/tutorials/02_gate_cutting_to_reduce_circuit_depth.ipynb


### PR DESCRIPTION
This can be reverted once a fix to https://github.com/Qiskit/qiskit/issues/13504 is merged to Qiskit's `main` branch.