### PR TITLE
Revert disabling of the second tutorial on dev version CI

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -45,4 +45,4 @@ jobs:
         run: |
           toxpyversion=$(echo ${{ matrix.python-version }} | sed -E 's/^([0-9]+)\.([0-9]+).*$/\1\2/')
           tox -epy${toxpyversion} -- --run-slow
-          tox -epy${toxpyversion}-notebook -- --ignore=docs/tutorials/02_gate_cutting_to_reduce_circuit_depth.ipynb
+          tox -epy${toxpyversion}-notebook


### PR DESCRIPTION
This reverts commit 30b158f61fdaa2ab8782d5fe8992247e56ad3f63 (PR #719).

Closes #714 (once CI passes due to https://github.com/Qiskit/qiskit/issues/13504 being fixed).