### PR TITLE
Pin numpy<2.2 in lint workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ lint = [
     "mypy==1.13.0",
     "reno>=3.4.0",
     "pylint==3.3.1",
+    "numpy<2.2",
 ]
 docs = [
     "Sphinx>=3.0.0",


### PR DESCRIPTION
Somehow, with numpy 2.2, the mypy fails with the following error:

```
qiskit_addon_cutting/cut_finding/circuit_interface.py:318: error: No overload variant of "__getitem__" of "Sequence" matches argument type "signedinteger[_32Bit | _64Bit]"  [call-overload]
qiskit_addon_cutting/cut_finding/circuit_interface.py:318: note: Possible overload variants:
qiskit_addon_cutting/cut_finding/circuit_interface.py:318: note:     def __getitem__(self, int, /) -> int | tuple[str, int]
qiskit_addon_cutting/cut_finding/circuit_interface.py:318: note:     def __getitem__(self, slice, /) -> Sequence[int | tuple[str, int]]
qiskit_addon_cutting/cut_finding/disjoint_subcircuits_state.py:330: error: Invalid index type "Hashable" for "ndarray[tuple[int, ...], dtype[signedinteger[_32Bit | _64Bit]]]"; expected type "SupportsIndex | slice | EllipsisType | _SupportsArray[dtype[numpy.bool[builtins.bool]] | dtype[integer[Any]]] | _NestedSequence[_SupportsArray[dtype[numpy.bool[builtins.bool]] | dtype[integer[Any]]]] | builtins.bool | int | _NestedSequence[builtins.bool | int] | tuple[SupportsIndex | slice | EllipsisType | _SupportsArray[dtype[numpy.bool[builtins.bool]] | dtype[integer[Any]]] | _NestedSequence[_SupportsArray[dtype[numpy.bool[builtins.bool]] | dtype[integer[Any]]]] | builtins.bool | int | _NestedSequence[builtins.bool | int] | None, ...] | None"  [index]
```

Hence we pin numpy as a workaround.