### PR TITLE
Update intersphinx mapping URLs & others

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -146,6 +146,6 @@ the only one that will be saved across different container runs.
 Platform Support
 ^^^^^^^^^^^^^^^^
 
-We expect this package to work on `any platform supported by Qiskit <https://docs.quantum.ibm.com/start/install#operating-system-support>`__. If
+We expect this package to work on `any platform supported by Qiskit <https://docs.quantum.ibm.com/guides/install-qiskit#operating-system-support>`__. If
 you are experiencing issues running the software on your device, you
 may consider :ref:`using this package within Docker <Option 3>`.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ### About
 
-[Qiskit addons](https://docs.quantum.ibm.com/guides/addons) are a collection of modular tools for building utility-scale workloads powered by Qiskit.
+[Qiskit addons](https://quantum.cloud.ibm.com/docs/guides/addons) are a collection of modular tools for building utility-scale workloads powered by Qiskit.
 
 This package implements circuit cutting.  In this technique, a handful of gates and/or wires are cut, resulting in smaller circuits that are better suited for execution on hardware.  The result of the original circuit can then be reconstructed; however, the trade-off is that the overall number of shots must be increased by a factor exponential in the number of cuts.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,9 +114,9 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
-    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
+    "qiskit": ("https://quantum.cloud.ibm.com/docs/api/qiskit/", None),
     "qiskit-ibm-runtime": (
-        "https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/",
+        "https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/",
         None,
     ),
     "qiskit-aer": ("https://qiskit.github.io/qiskit-aer/", None),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Qiskit addon: circuit cutting
    :alt: GitHub repository star counter badge
    :target: https://github.com/Qiskit/qiskit-addon-cutting
 
-`Qiskit addons <https://docs.quantum.ibm.com/guides/addons>`_ are a collection of modular tools for building utility-scale workloads powered by Qiskit.
+`Qiskit addons <https://quantum.cloud.ibm.com/docs/guides/addons>`_ are a collection of modular tools for building utility-scale workloads powered by Qiskit.
 
 This package implements circuit cutting.  In this technique, a handful of gates and/or wires are cut, resulting in smaller circuits that are better suited for execution on hardware.  The result of the original circuit can then be reconstructed; however, the trade-off is that the overall number of shots must be increased by a factor exponential in the number of cuts.
 

--- a/docs/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
+++ b/docs/tutorials/01_gate_cutting_to_reduce_circuit_width.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Gate Cutting to Reduce Circuit Width\n",
     "\n",
-    "In this notebook, we will work through the steps of a [Qiskit pattern](https://docs.quantum.ibm.com/guides/intro-to-patterns) while using **circuit cutting** to reduce the number of qubits in a circuit.  We will cut gates to enable us to reconstruct the expectation value of a four-qubit circuit using only two-qubit experiments.\n",
+    "In this notebook, we will work through the steps of a [Qiskit pattern](https://quantum.cloud.ibm.com/docs/guides/intro-to-patterns) while using **circuit cutting** to reduce the number of qubits in a circuit.  We will cut gates to enable us to reconstruct the expectation value of a four-qubit circuit using only two-qubit experiments.\n",
     "\n",
     "These are the steps that we will take:\n",
     "\n",

--- a/docs/tutorials/02_gate_cutting_to_reduce_circuit_depth.ipynb
+++ b/docs/tutorials/02_gate_cutting_to_reduce_circuit_depth.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "In this tutorial, we will reduce a circuit's depth by cutting distant gates, avoiding the swap gates that would otherwise be introduced by routing.\n",
     "\n",
-    "These are the steps that we will take in this [Qiskit pattern](https://docs.quantum.ibm.com/guides/intro-to-patterns):\n",
+    "These are the steps that we will take in this [Qiskit pattern](https://quantum.cloud.ibm.com/docs/guides/intro-to-patterns):\n",
     "\n",
     "- **Step 1: Map problem to quantum circuits and operators**:\n",
     "    - Map the hamiltonian onto a quantum circuit.\n",

--- a/docs/tutorials/03_wire_cutting_via_move_instruction.ipynb
+++ b/docs/tutorials/03_wire_cutting_via_move_instruction.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "In this tutorial, we will reconstruct expectation values of a seven-qubit circuit by splitting it into two four-qubit circuits using wire cutting.\n",
     "\n",
-    "These are the steps that we will take in this [Qiskit pattern](https://docs.quantum.ibm.com/guides/intro-to-patterns):\n",
+    "These are the steps that we will take in this [Qiskit pattern](https://quantum.cloud.ibm.com/docs/guides/intro-to-patterns):\n",
     "\n",
     "- **Step 1: Map problem to quantum circuits and operators**:\n",
     "    - Map the hamiltonian onto a quantum circuit.\n",

--- a/docs/tutorials/04_automatic_cut_finding.ipynb
+++ b/docs/tutorials/04_automatic_cut_finding.ipynb
@@ -268,7 +268,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Steps 3 and 4 of a [Qiskit pattern](https://docs.quantum.ibm.com/guides/intro-to-patterns) can then be performed as in the preceding tutorials."
+    "Steps 3 and 4 of a [Qiskit pattern](https://quantum.cloud.ibm.com/docs/guides/intro-to-patterns) can then be performed as in the preceding tutorials."
    ]
   }
  ],

--- a/releasenotes/notes/0.7/cutting-samplerv2-603b0c631a3330df.yaml
+++ b/releasenotes/notes/0.7/cutting-samplerv2-603b0c631a3330df.yaml
@@ -5,5 +5,5 @@ features:
     :class:`~qiskit.primitives.PrimitiveResult` object, which is
     returned by version 2 of the sampler primitive
     (:class:`~qiskit.primitives.BaseSamplerV2`).  See the `migration guide
-    <https://docs.quantum.ibm.com/migration-guides/qiskit-1.0-features#qiskitprimitives>`__
+    <https://quantum.cloud.ibm.com/docs/migration-guides/qiskit-1.0-features#qiskitprimitives>`__
     for details on upgrading to version 2 of the Qiskit primitives.

--- a/releasenotes/notes/0.7/prepare-0.7.0-48b344ae77523c34.yaml
+++ b/releasenotes/notes/0.7/prepare-0.7.0-48b344ae77523c34.yaml
@@ -6,7 +6,7 @@ prelude:
   workflow (CutQC) is now deprecated.  Additionally, this is the first
   CKT release to support version 2 of the Qiskit Runtime primitives.
   User are encouraged to `migrate to v2 primitives
-  <https://docs.quantum.ibm.com/migration-guides/v2-primitives>`__
+  <https://quantum.cloud.ibm.com/docs/migration-guides/v2-primitives>`__
   as soon as possible.
 
 other:


### PR DESCRIPTION
The documentation source of truth is moving to https://quantum.cloud.ibm.com/.