### PR TITLE
Convert inline math into displayed equation to avoid overflowing in the future

### DIFF
--- a/qiskit_addon_cutting/cutting_experiments.py
+++ b/qiskit_addon_cutting/cutting_experiments.py
@@ -53,7 +53,8 @@ def generate_cutting_experiments(
 
     In both cases, the subexperiment lists are ordered as follows:
 
-        :math:`[sample_{0}observable_{0}, \ldots, sample_{0}observable_{N-1}, sample_{1}observable_{0}, \ldots, sample_{M-1}observable_{N-1}]`
+    .. math::
+        [sample_{0}observable_{0}, \ldots, sample_{0}observable_{N-1}, sample_{1}observable_{0}, \ldots, sample_{M-1}observable_{N-1}]
 
     The coefficients will always be returned as a 1D array -- one coefficient for each unique sample.
 

--- a/qiskit_addon_cutting/cutting_reconstruction.py
+++ b/qiskit_addon_cutting/cutting_reconstruction.py
@@ -55,7 +55,8 @@ def reconstruct_expectation_values(
             to generate their experiments should take care to order their subexperiments as follows before submitting them
             to the sampler primitive:
 
-            :math:`[sample_{0}observable_{0}, \ldots, sample_{0}observable_{N-1}, sample_{1}observable_{0}, \ldots, sample_{M-1}observable_{N-1}]`
+            .. math::
+                [sample_{0}observable_{0}, \ldots, sample_{0}observable_{N-1}, sample_{1}observable_{0}, \ldots, sample_{M-1}observable_{N-1}]
 
         coefficients: A sequence containing the coefficient associated with each unique subexperiment. Each element is a tuple
             containing the coefficient (a ``float``) together with its :class:`.WeightType`, which denotes


### PR DESCRIPTION
This PR converts an inline math expression into a displayed equation. Soon, we will be changing how the inline expressions are showed on the website and we need to transform long expressions to have a better visualization of them and avoid any possible overflow.

Even though, the current expression looks good on the website right now, it will soon break if we don't apply this change. 

This is an example of the final render:

<img width="825" alt="Screenshot 2025-06-25 at 10 30 25" src="https://github.com/user-attachments/assets/370f02d8-5b64-4f8d-b2fb-cf4bdc5b8208" />
